### PR TITLE
Updates Retype workflow to use version 2

### DIFF
--- a/.github/workflows/retype.yml
+++ b/.github/workflows/retype.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: retypeapp/action-build@v1
+      - uses: retypeapp/action-build@v2
 
-      - uses: retypeapp/action-github-pages@v1
+      - uses: retypeapp/action-github-pages@v2
         with:
           update-branch: true


### PR DESCRIPTION
Will make it so the built page uses the new Retype version, 2.0.0, and newer as they are released.

I suggest before mergin this, update your local Retype installation and run through the pages with `retype watch` to see if anything needs adjustment.