### PR TITLE
Fixes EduMate > Attendance Workflow page's metadata

### DIFF
--- a/Edumate/Attendance Workflow.md
+++ b/Edumate/Attendance Workflow.md
@@ -1,11 +1,11 @@
 ---
 authors:
  - name: Sarah Dawson
-  email: 
-  link: 
-  avatar: ../static/SarahDawson_Icon.png
+   email: 
+   link: 
+   avatar: ../static/SarahDawson_Icon.png
 description: 
-title: AttendanceWorkflow
+title: Attendance Workflow
 icon: 
 layout: default
 order: 0


### PR DESCRIPTION
The Front Matter block in the page must follow YAML specification, that is very strict about text alignment/indentation.

The change makes it so the page title in left navigation bar reads just "Attendance Workflow" instead of the longer actual in-page title.